### PR TITLE
Added Responsible Team to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+#### Responsible Team: Design Systems
+
 vertical-collection
 =================
 


### PR DESCRIPTION
This change is needed for our alarming system. Periodic checks will search for inactive repos and contact responsible team to see if repo needs to be archived.